### PR TITLE
Folding lists

### DIFF
--- a/plugin/Touchdown.vim
+++ b/plugin/Touchdown.vim
@@ -43,6 +43,14 @@ function! GetListFold(lnum)
   endif
 endfunction
 
+function! GetFoldText()
+  " TODO: Conditionally apply this logic, else default
+  let nl = v:foldend - v:foldstart + 1
+  let linetext = substitute(getline(v:foldstart),"-","+",1)
+  let txt =  linetext . "\t (" . nl . ' lines hidden)'
+  return txt
+endfunction
+set foldtext=GetFoldText()
 set foldmethod=expr
 set foldexpr=GetListFold(v:lnum)
 

--- a/plugin/Touchdown.vim
+++ b/plugin/Touchdown.vim
@@ -6,8 +6,46 @@ if exists('g:touchdown__loaded')
 endif
 
 
-" Folding for markdown
-autocmd BufNewFile,BufRead *.md set foldmethod=indent
+" Folding for markdown lists
+function! IndentLevel(lnum)
+  return indent(a:lnum) / &shiftwidth
+endfunction
+
+function! NextNonBlankLine(lnum)
+  let numlines = line('$')
+  let current = a:lnum + 1
+
+  while current <= numlines
+    if getline(current) =~? '\v\S'
+      return current
+    endif
+
+    let current += 1
+  endwhile
+
+  return -2
+endfunction
+
+function! GetListFold(lnum)
+  if getline(a:lnum) =~? '\v^\s*$'
+    return '-1'
+  endif
+
+  let this_indent = IndentLevel(a:lnum)
+  let next_indent = IndentLevel(NextNonBlankLine(a:lnum))
+
+  if next_indent == this_indent
+    return this_indent
+  elseif next_indent < this_indent
+    return this_indent
+  elseif next_indent > this_indent
+    return '>' . next_indent
+  endif
+endfunction
+
+set foldmethod=expr
+set foldexpr=GetListFold(v:lnum)
+
 
 " GitHub Flavored Markdown states
 let g:touchdown__checkbox_states = [' ', 'x', ' ']

--- a/plugin/Touchdown.vim
+++ b/plugin/Touchdown.vim
@@ -6,6 +6,9 @@ if exists('g:touchdown__loaded')
 endif
 
 
+" Folding for markdown
+autocmd BufNewFile,BufRead *.md set foldmethod=indent
+
 " GitHub Flavored Markdown states
 let g:touchdown__checkbox_states = [' ', 'x', ' ']
 

--- a/plugin/Touchdown.vim
+++ b/plugin/Touchdown.vim
@@ -44,10 +44,14 @@ function! GetListFold(lnum)
 endfunction
 
 function! GetFoldText()
-  " TODO: Conditionally apply this logic, else default
-  let nl = v:foldend - v:foldstart + 1
-  let linetext = substitute(getline(v:foldstart),"-","+",1)
-  let txt =  linetext . "\t (" . nl . ' lines hidden)'
+  if (match(getline(v:foldstart), "[\s\t]*[-\*][\s\t]*.*") != -1)
+    let nl = v:foldend - v:foldstart + 1
+    let linetext = substitute(getline(v:foldstart),"-","+",1)
+    let txt =  linetext . "\t (" . nl . ' lines hidden)'
+  else
+    let txt = foldtext()
+  endif
+
   return txt
 endfunction
 set foldtext=GetFoldText()


### PR DESCRIPTION
- [x] Vim-flowy-like folding of lists
- [x] Only apply custom fold text logic to lists (`-` or `*`)

Will fix #6 